### PR TITLE
Fixed Links to ItemDetails and Author page

### DIFF
--- a/src/components/home/NewItems.jsx
+++ b/src/components/home/NewItems.jsx
@@ -97,7 +97,7 @@ const NewItems = () => {
                   <div className="nft__item">
                     <div className="author_list_pp">
                       <Link
-                        to="/author"
+                        to={`/author/${item.authorId}`}
                         data-bs-toggle="tooltip"
                         data-bs-placement="top"
                         title="Creator: Monica Lucas"
@@ -130,7 +130,7 @@ const NewItems = () => {
                         </div>
                       </div>
     
-                      <Link to="/item-details">
+                      <Link to={`/item-details/${item.nftId}`}>
                         <img
                           src={item.nftImage}
                           className="lazy nft__item_preview"
@@ -139,7 +139,7 @@ const NewItems = () => {
                       </Link>
                     </div>
                     <div className="nft__item_info">
-                      <Link to="/item-details">
+                      <Link to={`/item-details/${item.nftId}`}>
                         <h4>{item.title}</h4>
                       </Link>
                       <div className="nft__item_price">{item.price} ETH</div>


### PR DESCRIPTION
Fixed the links in the New Items feature to correctly redirect to the NFT-Item page and author page.