### PR TITLE
Fixed Links to NFT ItemDetails

### DIFF
--- a/src/components/author/AuthorItems.jsx
+++ b/src/components/author/AuthorItems.jsx
@@ -45,7 +45,7 @@ const AuthorItems = ({authorData}) => {
                           </div>
                         </div>
                       </div>
-                      <Link to="/item-details">
+                      <Link to={`/item-details/${item.nftId}`}>
                         <img
                           src={item.nftImage}
                           className="lazy nft__item_preview"
@@ -54,7 +54,7 @@ const AuthorItems = ({authorData}) => {
                       </Link>
                     </div>
                     <div className="nft__item_info">
-                      <Link to="/item-details">
+                      <Link to={`/item-details/${item.nftId}`}>
                         <h4>{item.title}</h4>
                       </Link>
                       <div className="nft__item_price">{item.price} ETH</div>


### PR DESCRIPTION
Fixed the links on the Author Page and they now correctly redirect to the NFT Item Details page.