### PR TITLE
Fixed hotCollections NFT Links

### DIFF
--- a/src/components/home/HotCollections.jsx
+++ b/src/components/home/HotCollections.jsx
@@ -83,13 +83,13 @@ const HotCollections = () => {
                       </Link>
                     </div>
                     <div className="nft_coll_pp">
-                      <Link to="/author">
+                      <Link to={`/author/${item.authorId}`}>
                         <img className="lazy pp-coll" src={item.authorImage} alt="" />
                       </Link>
                       <i className="fa fa-check"></i>
                     </div>
                     <div className="nft_coll_info">
-                      <Link to="/explore">
+                      <Link to={`/item-details/${item.nftId}`}>
                         <h4>{item.title}</h4>
                       </Link>
                       <span>ERC-{item.code}</span>


### PR DESCRIPTION
Fixed the hotCollections NFT Profile Pic and Title links to correctly redirect to the Author and NFT Item Details page.